### PR TITLE
allow capitalized functions (react's function components)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovos-media/coding-standard",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "ovos-media Coding Standard",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tslint.ts
+++ b/tslint.ts
@@ -42,6 +42,16 @@ const rules : tslint.Configuration.RawRulesConfig = Object.assign({}, rulesAirbn
     ignoreStrings: true,
     ignoreTemplateLiterals: true,
   }],
+  'function-name': [
+    true,
+    {
+      'function-regex':         /^[a-zA-Z$][a-zA-Z\d]+$/, // allow React function components
+      'method-regex':           /^[a-z$][a-zA-Z\d]+$/,
+      'private-method-regex':   /^[a-z$][a-zA-Z\d]+$/,
+      'protected-method-regex': /^[a-z$][a-zA-Z\d]+$/,
+      'static-method-regex':    /^[a-z$][a-zA-Z\d]+$/,
+    },
+  ],
   'variable-name': false,
   'no-this-assignment': [true, {'allow-destructuring': true}],
   'import-name': false, // from tslint-microsoft-contrib


### PR DESCRIPTION
Allows function (not method) names to be capitalized. Named functions are better for React components than lambdas (anonymous functions) as they provide more debug information.