### PR TITLE
update dependencies, disable jsx-wrap-multiline

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,15 +15,16 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "tslint-config-airbnb": "^5.11.0",
-    "tslint-react": "^3.6.0"
+    "tslint-config-airbnb": "git+https://github.com/ovos/tslint-config-airbnb.git#5.11.1-mod.0",
+    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-react": "^4.0.0"
   },
   "devDependencies": {
-    "@types/node": "^10.11.7",
-    "@types/prettier": "^1.13.2",
-    "prettier": "^1.14.3",
-    "tslint": "^5.11.0",
-    "typescript": "^3.1.2"
+    "@types/node": "^12.7.4",
+    "@types/prettier": "^1.18.2",
+    "prettier": "^1.18.2",
+    "tslint": "^5.19.0",
+    "typescript": "^3.6.2"
   },
   "files": [
     "/index.js",

--- a/tslint.ts
+++ b/tslint.ts
@@ -7,8 +7,9 @@ const rulesReact = tslintReact.rules;
 
 const rules : tslint.Configuration.RawRulesConfig = Object.assign({}, rulesAirbnb, rulesReact, {
   // differences from airbnb ruleset
-  'no-increment-decrement': false,
+  'prefer-array-literal': [true, {'allow-size-argument': true}],
   align: false,
+  'increment-decrement': false,
   whitespace: [
     true,
     'check-branch',
@@ -95,25 +96,13 @@ const rules : tslint.Configuration.RawRulesConfig = Object.assign({}, rulesAirbn
    */
 });
 
-// copy rules to jsRules
-// until this is merged https://github.com/palantir/tslint/pull/3641
-const jsRules = Object.assign({}, rules);
-// delete typescriptOnly rules
-delete jsRules['prefer-array-literal'];
-delete jsRules['no-function-constructor-with-string-args'];
-delete jsRules['no-increment-decrement'];
-delete jsRules['no-unused-variable'];
-delete jsRules['no-boolean-literal-compare'];
-delete jsRules['function-name'];
-delete jsRules['import-name'];
-
 const config: tslint.Configuration.RawConfigFile = {
   extends: [
     'tslint-config-airbnb',
     'tslint-react',
   ],
   rules: rules,
-  jsRules: jsRules,
+  jsRules: true,
 };
 
 export = config;

--- a/tslint.ts
+++ b/tslint.ts
@@ -75,6 +75,10 @@ const rules : tslint.Configuration.RawRulesConfig = Object.assign({}, rulesAirbn
   // https://stackoverflow.com/questions/43968779/are-lambda-in-jsx-attributes-an-anti-pattern/43968902#43968902
   'jsx-no-lambda': false,
   'jsx-boolean-value': false,
+  // disabled because of false positives and being unmaintained (and being incompatible with prettier)
+  // https://github.com/palantir/tslint-react/pull/194#issuecomment-478307364
+  // https://github.com/palantir/tslint-react/issues/79#issuecomment-289923337
+  'jsx-wrap-multiline': false,
 
   // additions
   'no-console': true,


### PR DESCRIPTION
1) update for latest tslint, tslint-react, tslint-consistent-codestyle
and tslint-microsoft-contrib through modified tslint-config-airbnb (the original seems to be no longer maintained) - https://github.com/ovos/tslint-config-airbnb/tree/mod
2) disabled jsx-wrap-multiline from tslint-react - because of false positives and being unmaintained (and being incompatible with prettier)
- palantir/tslint-react#194 (comment)
- palantir/tslint-react#79 (comment)