### PR TITLE
add ordered-imports rule 

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "arrowParens": "avoid"
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "release": "standard-version"
   },
   "dependencies": {
+    "resolve": "^1.12.0",
     "tslint-config-airbnb": "git+https://github.com/ovos/tslint-config-airbnb.git#5.11.1-mod.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-react": "^4.0.0"
@@ -23,7 +24,7 @@
     "@types/node": "^12.7.4",
     "@types/prettier": "^1.18.2",
     "prettier": "^1.18.2",
-    "tslint": "^5.19.0",
+    "tslint": "^5.20.0",
     "typescript": "^3.6.2"
   },
   "files": [

--- a/tslint.ts
+++ b/tslint.ts
@@ -54,20 +54,17 @@ const importGroups = [
     match: coreModulesRegex,
     order: 10,
   },
-].concat(
-  dependenciesRegex
-    ? {
-      name: 'dependencies',
-      match: dependenciesRegex,
-      order: 20,
-    }
-    : [],
+  dependenciesRegex && {
+    name: 'dependencies',
+    match: dependenciesRegex,
+    order: 20,
+  },
   {
     name: 'the rest, incl. typescript absolute imports',
     match: '\\.*',
     order: 40,
-  }
-);
+  },
+].filter(Boolean); // filter out empty dependencies group
 
 const rules : tslint.Configuration.RawRulesConfig = Object.assign({}, rulesAirbnb, rulesReact, {
   // differences from airbnb ruleset

--- a/tslint.ts
+++ b/tslint.ts
@@ -1,9 +1,73 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as coreModules from 'resolve/lib/core';
 import * as tslint from 'tslint';
 import * as tslintAirbnb from 'tslint-config-airbnb';
 const tslintReact = require('tslint-react');
 
 const rulesAirbnb = tslintAirbnb.rules;
 const rulesReact = tslintReact.rules;
+
+// prepare regex for node core modules for 'ordered-imports' rule
+const modules = Object.entries(coreModules as Record<string, boolean>).reduce(
+  (acc: string[], [module, enabled]) => {
+    enabled && !module.startsWith('_') && acc.push(module);
+    return acc;
+  },
+  []
+);
+const coreModulesRegex = '^(' + modules.join('|') + ')$';
+
+// prepare import groups for 'ordered-imports' rule
+const projectPackageJson = path.join(process.cwd(), 'package.json');
+let dependenciesRegex;
+if (fs.existsSync(projectPackageJson)) {
+  const packageJson = require(projectPackageJson);
+  const dependencies = [
+    ...Object.keys(packageJson.dependencies || {}),
+    ...Object.keys(packageJson.devDependencies || {}),
+  ];
+
+  if (dependencies.length) {
+    dependenciesRegex = '^(' + dependencies.join('|').replace(/\./g, '\\\\.') + ')(/|$)';
+  }
+}
+
+const importGroups = [
+  {
+    name: 'aliased paths, which begin with tilde in our convention',
+    match: '^~',
+    order: 30,
+  },
+  {
+    name: 'parent directories',
+    match: '^\\.\\.',
+    order: 50,
+  },
+  {
+    name: 'current directory',
+    match: '^\\.',
+    order: 60,
+  },
+  {
+    name: 'built-in node modules',
+    match: coreModulesRegex,
+    order: 10,
+  },
+].concat(
+  dependenciesRegex
+    ? {
+      name: 'dependencies',
+      match: dependenciesRegex,
+      order: 20,
+    }
+    : [],
+  {
+    name: 'the rest, incl. typescript absolute imports',
+    match: '\\.*',
+    order: 40,
+  }
+);
 
 const rules : tslint.Configuration.RawRulesConfig = Object.assign({}, rulesAirbnb, rulesReact, {
   // differences from airbnb ruleset
@@ -87,6 +151,11 @@ const rules : tslint.Configuration.RawRulesConfig = Object.assign({}, rulesAirbn
   'no-for-in-array': true,
   'no-return-await': true,
   'no-unused': [true, 'ignore-parameters'], // instead of "noUnusedLocals" in typescript
+  'ordered-imports': [true, {
+    'named-imports-order': 'lowercase-last',
+    'grouped-imports': true,
+    groups: importGroups,
+  }],
 
   // comments
   /**


### PR DESCRIPTION
with following predefined dynamic grouping config:

1. built-in node modules
2. dependencies (read from project's package.json)
3. aliased paths, which begin with tilde (~) in our convention
4. the rest, incl. typescript absolute imports
5. parent directories
6. current directory