### PR TITLE
prettier: lower printWidth from 120 to 100

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "tslint-react-hooks": "^2.2.2"
   },
   "devDependencies": {
-    "@types/node": "^12.7.4",
-    "@types/prettier": "^1.18.2",
-    "prettier": "^1.18.2",
+    "@types/node": "^13.11.1",
+    "@types/prettier": "^2.0.0",
+    "prettier": "^2.0.4",
     "tslint": "^5.20.0",
     "typescript": "^3.6.2"
   },

--- a/prettier.ts
+++ b/prettier.ts
@@ -7,7 +7,7 @@ const config: prettier.Options = {
   // https://github.com/prettier/prettier/issues/4160
   // https://github.com/prettier/prettier/issues/4298
   // https://github.com/prettier/prettier/issues/4658
-  printWidth: 120,
+  printWidth: 100,
   singleQuote: true,
   trailingComma: "es5",
   // neither "avoid" nor "always" plays well with tslint's "ter-arrow-parens"


### PR DESCRIPTION
prettier: lower printWidth from 120 to 100
- as the formatting has changed slightly in prettier v2.x (e.g. https://github.com/prettier/prettier/pull/6685)
- 100 may suit more projects out-of-the-box than 120