### PR TITLE
chore(tslint-react): updated, no warning when using tslint 6 and yarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "resolve": "^1.12.0",
     "tslint-config-airbnb": "git+https://github.com/ovos/tslint-config-airbnb.git#5.11.1-mod.0",
     "tslint-consistent-codestyle": "^1.15.1",
-    "tslint-react": "^4.0.0",
+    "tslint-react": "^5.0.0",
     "tslint-react-hooks": "^2.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Until we switch to eslint, this will remove one of the warnings we get, when we use tslint 6. We use tslint 6 in ovos-play everywhere, but several packages in this repo throw warnings when used with tslint 6. Not sure why we even do this, considering that this package still uses tslint 5 and I am not even sure if stuff works with this mix.

Also I noticed that yarn.lock is not commited in the repo, is this on purpose?

But alas, this removes the warning about tslint-react.
![image](https://user-images.githubusercontent.com/7806108/93201756-ea16dd00-f751-11ea-882f-b6f53f427c18.png)
