### PR TITLE
eslint: add @stylistic/jsx-quotes rule

### DIFF
--- a/eslint.ts
+++ b/eslint.ts
@@ -432,6 +432,7 @@ function customize(options: CustomizeOptions = {}) {
           '@stylistic/jsx-indent': ['error', indent],
           '@stylistic/jsx-indent-props': ['error', indent],
           '@stylistic/jsx-props-no-multi-spaces': 'error',
+          '@stylistic/jsx-quotes': 'error',
           '@stylistic/jsx-self-closing-comp': 'error', // replaces `react/self-closing-comp`, even though it's not deprecated yet
           '@stylistic/jsx-tag-spacing': [
             'error',


### PR DESCRIPTION
add [@stylistic/jsx-quotes](https://eslint.style/rules/default/jsx-quotes) rule

I missed it because it's not listed at https://eslint.style/packages/jsx for some reason 🙈 https://github.com/eslint-stylistic/eslint-stylistic/issues/303 🤷‍♂️