### PR TITLE
eslint v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The configuration is based on the recommended rulesets from [ESLint](https://esl
 
 It also includes [ESLint Stylistic](https://eslint.style/) which replaces deprecated rules from eslint and typescript-eslint.
 
-Currently, it uses ESLint v8 and typescript-eslint v6. (nodejs v16.10+ required)
-The upgrade to ESLint v9 and typescript-eslint v8 is planned for the next major release.
+Currently, it uses ESLint v9 and typescript-eslint v8. (nodejs v18.18+ required)
+If you need to use this package on older nodejs v16, you may switch to older v2.x version, which is based on ESLint v8 (nodejs v16.10+ required)
 
 
 `@ovos-media/coding-standard/eslint` exports a function that accepts an object with the following options:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The configuration is based on the recommended rulesets from [ESLint](https://esl
 It also includes [ESLint Stylistic](https://eslint.style/) which replaces deprecated rules from eslint and typescript-eslint.
 
 Currently, it uses ESLint v9 and typescript-eslint v8. (nodejs v18.18+ required)
-If you need to use this package on older nodejs v16, you may switch to older v2.x version, which is based on ESLint v8 (nodejs v16.10+ required)
+If you need to use this package on older nodejs, you can try the v2.x version, which is based on ESLint v8 (nodejs v16.10+ required)
 
 
 `@ovos-media/coding-standard/eslint` exports a function that accepts an object with the following options:

--- a/eslint.ts
+++ b/eslint.ts
@@ -51,7 +51,7 @@ const shared: Linter.RulesRecord = {
  * @param {boolean} [options.mocha=false] - Whether to enable Mocha-specific rules.
  * @param {boolean} [options.react=false] - Whether to enable React-specific rules.
  * @param {boolean} [options.vitest=false] - Whether to enable Vitest-specific rules.
- * @returns {import('eslint').Linter.FlatConfig[]} requires @types/eslint to be installed for FlatConfig type to appear on Linter - https://stackoverflow.com/a/75684357/3729316
+ * @returns {import('eslint').Linter.Config[]}
  */
 function customize(options: CustomizeOptions = {}) {
   const {
@@ -66,7 +66,7 @@ function customize(options: CustomizeOptions = {}) {
   } = options;
   const consoleUsage = options.console ?? (react ? 'ban-log' : 'allow');
 
-  const config: Linter.FlatConfig[] = [
+  const config: Linter.Config[] = [
     // common settings for all files
     {
       ignores: ['node_modules', 'build', 'coverage', '.yalc', 'vite.config.ts.*'],
@@ -98,7 +98,7 @@ function customize(options: CustomizeOptions = {}) {
       plugins: {
         '@typescript-eslint': { rules: tsPlugin.rules as any },
         import: importPlugin,
-      } satisfies Linter.FlatConfig['plugins'],
+      } satisfies Linter.Config['plugins'],
       settings: {
         // `import-x` prefix is hardcoded in `eslint-plugin-import-x` to read its settings, ignores the alias defined in `plugins`
         'import-x/resolver': { typescript: { alwaysTryTypes: true } },
@@ -474,7 +474,7 @@ function customize(options: CustomizeOptions = {}) {
       ],
       languageOptions: {
         globals: {
-          ...globals.jest,
+          ...jestPlugin.environments.globals.globals,
           DB: 'readonly',
           GQL: 'readonly',
           Setup: 'readonly',
@@ -485,7 +485,6 @@ function customize(options: CustomizeOptions = {}) {
         jest: jestPlugin,
       },
       rules: {
-        // flat config is not supported by eslint-plugin-jest yet - https://github.com/jest-community/eslint-plugin-jest/issues/1408
         ...jestPlugin.configs.recommended.rules,
         // the recommended set is too strict for us. Disable rules which we do not want.
         // https://github.com/jest-community/eslint-plugin-jest#rules
@@ -554,18 +553,13 @@ function customize(options: CustomizeOptions = {}) {
     const mochaPlugin = require('eslint-plugin-mocha');
     config.push(
       {
+        ...mochaPlugin.configs.flat.recommended,
         name: 'mocha',
         files: [
           `${testsDir}/**/*.?(c|m)[jt]s`,
           '**/__tests__/**/*.?(c|m)[jt]s',
           '**/*.{spec,test}.?(c|m)[jt]s',
         ],
-        languageOptions: {
-          globals: globals.mocha,
-        },
-        plugins: {
-          mocha: mochaPlugin,
-        },
         rules: {
           // https://github.com/lo1tuma/eslint-plugin-mocha#rules
           ...mochaPlugin.configs.flat.recommended.rules,
@@ -596,13 +590,13 @@ function customize(options: CustomizeOptions = {}) {
   if (cypress) {
     const cypressPlugin = require('eslint-plugin-cypress/flat');
     config.push({
+      ...cypressPlugin.configs.recommended,
       name: 'cypress',
       files: [
         `${testsDir}/**/*.?(c|m)[jt]s`,
         '**/__tests__/**/*.?(c|m)[jt]s',
         '**/*.{spec,test}.?(c|m)[jt]s',
       ],
-      ...cypressPlugin.configs.recommended,
       rules: {
         ...cypressPlugin.configs.recommended.rules,
         // Even though cypress is based on mocha, and uses `this` in regular functions to access the test context,

--- a/eslint.ts
+++ b/eslint.ts
@@ -400,7 +400,10 @@ function customize(options: CustomizeOptions = {}) {
         rules: {
           // allow i.a. `type Props = {}` in react components
           // https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-675156492
-          '@typescript-eslint/no-empty-object-type': ['error', { allowWithName: 'Props$' }],
+          '@typescript-eslint/no-empty-object-type': [
+            'error',
+            { allowInterfaces: 'with-single-extends', allowWithName: 'Props$' },
+          ],
         },
       },
       // our rules and overrides (react 2/2: jsx+tsx)

--- a/eslint.ts
+++ b/eslint.ts
@@ -5,6 +5,7 @@ import * as tsParser from '@typescript-eslint/parser';
 import { Linter } from 'eslint';
 import checkFilePlugin from 'eslint-plugin-check-file';
 import * as importPlugin from 'eslint-plugin-import'; // aliased to eslint-plugin-import-x https://github.com/un-ts/eslint-plugin-import-x
+import perfectionist from 'eslint-plugin-perfectionist';
 import globals from 'globals';
 
 type CustomizeOptions = {
@@ -82,6 +83,21 @@ function customize(options: CustomizeOptions = {}) {
       plugins: {
         // https://eslint.style/ providing replacement for formatting rules, which are now deprecated in eslint and @typescript-eslint
         '@stylistic': { rules: stylistic.rules },
+        perfectionist,
+      },
+      settings: {
+        // https://perfectionist.dev/guide/getting-started#settings
+        perfectionist: {
+          type: 'custom',
+          ignoreCase: false,
+          // 'perfectionist' uses .localeCompare() which by default which sorts '123..AaBbCc..'
+          // we want to put uppercase before lowercase, the rest stays the same (esp. symbols)
+          // Alphabet from 'perfectionist' could be used, such as
+          // `Alphabet.generateRecommendedAlphabet().sortByNaturalSort('en-US').placeAllWithCaseBeforeAllWithOtherCase('uppercase').getCharacters()`
+          // but that contains 128k chars, which is unnecessarily large
+          // so recreated only the needed part of the alphabet, with uppercase before lowercase
+          alphabet: '_-.@/#~$0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+        },
       },
     },
     // common settings for typescript files
@@ -163,7 +179,10 @@ function customize(options: CustomizeOptions = {}) {
         // we still sometimes want to use dynamic, sync `require()` instead of `await import()`
         '@typescript-eslint/no-require-imports': 'off',
         // allow `interface I extends Base<Param> {}` syntax
-        '@typescript-eslint/no-empty-object-type': ['error', { allowInterfaces: 'with-single-extends' }],
+        '@typescript-eslint/no-empty-object-type': [
+          'error',
+          { allowInterfaces: 'with-single-extends' },
+        ],
         // even though the rules blow are already reconfigured for eslint:recommended,
         // they need to be reconfigured again for typescript files, with the same options repeated
         '@typescript-eslint/no-unused-expressions': shared['no-unused-expressions'],
@@ -355,6 +374,11 @@ function customize(options: CustomizeOptions = {}) {
         'no-param-reassign': 'error',
         'object-shorthand': 'error',
         'one-var': ['error', 'never'],
+        'perfectionist/sort-named-exports': ['error', { groupKind: 'types-first' }],
+        'perfectionist/sort-named-imports': [
+          'error',
+          { ignoreAlias: true, groupKind: 'types-first' },
+        ],
         'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
         ...(consoleUsage !== 'allow' && {
           'no-console':
@@ -583,7 +607,7 @@ function customize(options: CustomizeOptions = {}) {
         rules: {
           'mocha/no-exports': 'off',
         },
-      },
+      }
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovos-media/coding-standard",
-  "version": "3.0.0-rc.2",
+  "version": "3.0.0-rc.3",
   "description": "ovos-media coding standard",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovos-media/coding-standard",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "description": "ovos-media coding standard",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,12 @@
   "repository": "https://github.com/ovos/coding-standard",
   "homepage": "https://github.com/ovos/coding-standard",
   "scripts": {
-    "prepublish": "yarn build",
+    "prepublish": "npm run build",
     "lint": "eslint .",
     "build": "tsc -p ./tsconfig.json"
   },
   "dependencies": {
     "@stylistic/eslint-plugin": "^2.12.1",
-    "@types/eslint": "^9.6.1",
     "@typescript-eslint/eslint-plugin": "^8.19.1",
     "@typescript-eslint/parser": "^8.19.1",
     "@typescript-eslint/utils": "^8.19.1",
@@ -33,13 +32,13 @@
   },
   "devDependencies": {
     "@types/eslint-plugin-mocha": "10.4.0",
-    "@types/node": "20.17.10",
+    "@types/node": "22.10.5",
     "@types/prettier": "3.0.0",
     "prettier": "3.4.2",
     "typescript": "5.7.2"
   },
   "engines": {
-    "node": ">=16.10"
+    "node": ">=18.18"
   },
   "files": [
     "/eslint.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovos-media/coding-standard",
-  "version": "2.0.2",
+  "version": "3.0.0-rc.0",
   "description": "ovos-media coding standard",
   "main": "index.js",
   "types": "index.d.ts",
@@ -9,35 +9,34 @@
   "repository": "https://github.com/ovos/coding-standard",
   "homepage": "https://github.com/ovos/coding-standard",
   "scripts": {
-    "prepublish": "yarn run build",
-    "lint": "yarn run eslint .",
-    "build": "tsc -p ./tsconfig.json",
-    "release": "standard-version"
+    "prepublish": "yarn build",
+    "lint": "eslint .",
+    "build": "tsc -p ./tsconfig.json"
   },
   "dependencies": {
-    "@stylistic/eslint-plugin": "^1.8.1",
-    "@types/eslint": "8.56.10",
-    "@typescript-eslint/eslint-plugin": "^6.21.0",
-    "@typescript-eslint/parser": "^6.21.0",
-    "eslint": "^8.57.0",
-    "eslint-import-resolver-typescript": "^3.6.1",
-    "eslint-plugin-check-file": "2.6.2",
-    "eslint-plugin-cypress": "^3.3.0",
-    "eslint-plugin-import": "npm:eslint-plugin-import-x@0.2.0",
-    "eslint-plugin-jest": "28.4.0",
-    "eslint-plugin-mocha": "^10.4.3",
-    "eslint-plugin-react": "^7.34.2",
-    "eslint-plugin-react-hooks": "^4.6.2",
-    "eslint-plugin-vitest": "0.3.10",
-    "globals": "^13.24.0"
+    "@stylistic/eslint-plugin": "^2.12.1",
+    "@types/eslint": "^9.6.1",
+    "@typescript-eslint/eslint-plugin": "^8.19.1",
+    "@typescript-eslint/parser": "^8.19.1",
+    "@typescript-eslint/utils": "^8.19.1",
+    "@vitest/eslint-plugin": "^1.1.24",
+    "eslint": "^9.17.0",
+    "eslint-import-resolver-typescript": "^3.7.0",
+    "eslint-plugin-check-file": "^2.8.0",
+    "eslint-plugin-cypress": "^4.1.0",
+    "eslint-plugin-import": "npm:eslint-plugin-import-x@^4.6.1",
+    "eslint-plugin-jest": "^28.10.0",
+    "eslint-plugin-mocha": "^10.5.0",
+    "eslint-plugin-react": "^7.37.3",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "globals": "^15.14.0"
   },
   "devDependencies": {
     "@types/eslint-plugin-mocha": "10.4.0",
-    "@types/eslint__js": "8.42.3",
-    "@types/node": "20.14.1",
+    "@types/node": "20.17.10",
     "@types/prettier": "3.0.0",
-    "prettier": "3.3.0",
-    "typescript": "5.4.5"
+    "prettier": "3.4.2",
+    "typescript": "5.7.2"
   },
   "engines": {
     "node": ">=16.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovos-media/coding-standard",
-  "version": "3.0.0-rc.0",
+  "version": "3.0.0-rc.1",
   "description": "ovos-media coding standard",
   "main": "index.js",
   "types": "index.d.ts",
@@ -26,6 +26,7 @@
     "eslint-plugin-import": "npm:eslint-plugin-import-x@^4.6.1",
     "eslint-plugin-jest": "^28.10.0",
     "eslint-plugin-mocha": "^10.5.0",
+    "eslint-plugin-perfectionist": "^4.6.0",
     "eslint-plugin-react": "^7.37.3",
     "eslint-plugin-react-hooks": "^5.1.0",
     "globals": "^15.14.0"


### PR DESCRIPTION
## Update eslint to v9 and all related dependencies

Refreshed rules config - to avoid breaking changes.

### indent rule

indent rule should work better now - although it's still buggy - there might be reports on code which was not reported before.

The biggest pain point might be that `typeof` does not mark a variable as used by `no-unused-vars` rule - now error is reported. Related thread: https://github.com/typescript-eslint/typescript-eslint/issues/10266

### Added [perfectionist/sort-named-imports](https://perfectionist.dev/rules/sort-named-imports) and [perfectionist/sort-named-exports](https://perfectionist.dev/rules/sort-named-exports)

We had named imports sorted in v1 when tslint was taking care of that. But it got lost during migration to eslint, as I wrongly assumed that import/order will take care of that.

Later on, the support for sorting named imports (but still not exports) was added to the original eslint-plugin-import import-js/eslint-plugin-import#3043 but we have switched to eslint-plugin-import-x since and the porting request of that feature is still pending. un-ts/eslint-plugin-import-x#225

We could consider switching back to eslint-plugin-import but it still has a set of its own, still unresolved issues.
Instead, I decided to try [eslint-plugin-perfectionist](https://perfectionist.dev/) and the sorting rules from that. Note we are sticking with import/order for sorting and grouping imports for the time being, as more time would be needed to convert the sorting and grouping config to achieve similar behaviour with the perfectionist/sort-imports rule.

There is also [perfectionist/sort-exports](https://perfectionist.dev/rules/sort-exports) rule, but it does not provide config options to define grouping and custom sorting, to achieve similar behaviour to import/order with our custom config applied, so for now we won't enforce that rule.

