### PR TITLE
update `@stylistic/eslint-plugin` to v3 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ The configuration is based on the recommended rulesets from [ESLint](https://esl
 
 It also includes [ESLint Stylistic](https://eslint.style/) which replaces deprecated rules from eslint and typescript-eslint.
 
-Currently, it uses ESLint v9 and typescript-eslint v8. (nodejs v18.18+ required)
-If you need to use this package on older nodejs, you can try the v2.x version, which is based on ESLint v8 (nodejs v16.10+ required)
-
+Currently, it uses ESLint v9 and typescript-eslint v8. (nodejs v18.18+ required)<br />
+If you need to use this package on older nodejs, you can try the v2.x version, which is based on ESLint v8. (nodejs v16.10+ required)
 
 `@ovos-media/coding-standard/eslint` exports a function that accepts an object with the following options:
 

--- a/eslint.ts
+++ b/eslint.ts
@@ -324,7 +324,7 @@ function customize(options: CustomizeOptions = {}) {
         '@stylistic/quotes': [
           'error',
           'single',
-          { allowTemplateLiterals: true, avoidEscape: true },
+          { allowTemplateLiterals: 'avoidEscape', avoidEscape: true },
         ],
         '@stylistic/rest-spread-spacing': ['error', 'never'],
         '@stylistic/semi': 'error',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovos-media/coding-standard",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.4",
   "description": "ovos-media coding standard",
   "main": "index.js",
   "types": "index.d.ts",
@@ -28,7 +28,7 @@
     "eslint-plugin-mocha": "^10.5.0",
     "eslint-plugin-perfectionist": "^4.7.0",
     "eslint-plugin-react": "^7.37.4",
-    "eslint-plugin-react-hooks": "^5.1.0",
+    "eslint-plugin-react-hooks": "5.0.0 || ^5.2.0",
     "globals": "^15.14.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,29 +14,28 @@
     "build": "tsc -p ./tsconfig.json"
   },
   "dependencies": {
-    "@stylistic/eslint-plugin": "^2.12.1",
-    "@typescript-eslint/eslint-plugin": "^8.19.1",
-    "@typescript-eslint/parser": "^8.19.1",
-    "@typescript-eslint/utils": "^8.19.1",
-    "@vitest/eslint-plugin": "^1.1.24",
-    "eslint": "^9.17.0",
+    "@stylistic/eslint-plugin": "^3.0.1",
+    "@typescript-eslint/eslint-plugin": "^8.22.0",
+    "@typescript-eslint/parser": "^8.22.0",
+    "@typescript-eslint/utils": "^8.22.0",
+    "@vitest/eslint-plugin": "^1.1.25",
+    "eslint": "^9.19.0",
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-check-file": "^2.8.0",
     "eslint-plugin-cypress": "^4.1.0",
     "eslint-plugin-import": "npm:eslint-plugin-import-x@^4.6.1",
-    "eslint-plugin-jest": "^28.10.0",
+    "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-mocha": "^10.5.0",
-    "eslint-plugin-perfectionist": "^4.6.0",
-    "eslint-plugin-react": "^7.37.3",
+    "eslint-plugin-perfectionist": "^4.7.0",
+    "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.1.0",
     "globals": "^15.14.0"
   },
   "devDependencies": {
     "@types/eslint-plugin-mocha": "10.4.0",
-    "@types/node": "22.10.5",
-    "@types/prettier": "3.0.0",
+    "@types/node": "22.10.10",
     "prettier": "3.4.2",
-    "typescript": "5.7.2"
+    "typescript": "5.7.3"
   },
   "engines": {
     "node": ">=18.18"


### PR DESCRIPTION
followup to #9

1. update `@stylistic/eslint-plugin` to [v3](https://github.com/eslint-stylistic/eslint-stylistic/releases/tag/v3.0.0) 
and bump other deps to their latest versions

note: there is a breaking change (but auto-fixable) with `@stylistic/quotes` now configured with `allowTemplateLiterals: 'avoidEscape'`
https://github.com/eslint-stylistic/eslint-stylistic/releases/tag/v3.0.0
https://eslint.style/rules/default/quotes

2. do not use eslint-plugin-react-hooks v5.1.0
because of a bug in `rules-of-hooks` https://github.com/facebook/react/issues/31687