### PR TITLE
use `chai-friendly/no-unused-expressions` for cypress test files

### DIFF
--- a/eslint.ts
+++ b/eslint.ts
@@ -616,9 +616,14 @@ function customize(options: CustomizeOptions = {}) {
 
   if (cypress) {
     const cypressPlugin = require('eslint-plugin-cypress/flat');
+    const chaiFriendlyPlugin = require('eslint-plugin-chai-friendly');
     config.push({
       ...cypressPlugin.configs.recommended,
       name: 'cypress',
+      plugins: {
+        ...cypressPlugin.configs.recommended.plugins,
+        'chai-friendly': chaiFriendlyPlugin,
+      },
       files: [
         `${testsDir}/**/*.?(c|m)[jt]s`,
         '**/__tests__/**/*.?(c|m)[jt]s',
@@ -632,6 +637,10 @@ function customize(options: CustomizeOptions = {}) {
         // Still when `this` context needs to be accessed, a dev can easily convert an arrow function to a regular function.
         // This rule comes from our default config for `mocha`.
         'mocha/no-mocha-arrows': 'off',
+        // allow 'expect(foo).to.be.true' https://github.com/ihordiachenko/eslint-plugin-chai-friendly
+        'no-unused-expressions': 'off',
+        '@typescript-eslint/no-unused-expressions': 'off',
+        'chai-friendly/no-unused-expressions': shared['no-unused-expressions'],
       },
     });
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@vitest/eslint-plugin": "^1.1.25",
     "eslint": "^9.19.0",
     "eslint-import-resolver-typescript": "^3.7.0",
+    "eslint-plugin-chai-friendly": "^1.0.1",
     "eslint-plugin-check-file": "^2.8.0",
     "eslint-plugin-cypress": "^4.1.0",
     "eslint-plugin-import": "npm:eslint-plugin-import-x@^4.6.1",


### PR DESCRIPTION
to allow `expect(foo).to.be.true`

https://github.com/ihordiachenko/eslint-plugin-chai-friendly
https://github.com/cypress-io/eslint-plugin-cypress#cypress-and-chai-recommended